### PR TITLE
feat(cli): Add support for TypeScript files

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -277,7 +277,7 @@ fn get_icon(entry: &DirEntry) -> ColoredString {
         if let Some(extension) = Path::new(&file_name).extension() {
             match extension.to_string_lossy().as_ref() {
                 "rs" => "🦀 ".red(),
-                "js" => "📜 ".yellow(),
+                "js" | "ts" => "📜 ".yellow(),
                 "py" => "🐍 ".blue(),
                 "md" => "📝 ".white(),
                 "jpg" | "png" | "gif" => "🖼️ ".magenta(),


### PR DESCRIPTION
Adds support for TypeScript files in the file icon display.
TypeScript files are now displayed with the same yellow file icon
as JavaScript files.